### PR TITLE
Add `basic_auth` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # MagicPipe Changelog
 
+## Unreleased
+* Allow to set the `basic_auth` config as a proc which gets the topic name passed.
+Example:
+```ruby
+basic_auth: ->(topic) {
+    username = ENV["TOPIC_#{topic.singularize.upcase}_USER"]
+    password = ENV["SECRET_PASSWORD"]
+    "#{username}:#{password}"
+}
+```
+It should always return a string in the format `USERNAME:PASSWORD`. Instead
+of using a proc this string can be set directly:
+```ruby
+basic_auth: "foo:bar"
+```
+In favor of this `basic_auth_user` and `basic_auth_password` have been removed.
+
 ## v0.2.0
 
 Enhancing the HTTPS transport:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $magic_pipe = MagicPipe.build do |mp|
   }
   mp.https_transport_options = {
     url: "https://my.receiver.service/foo",
-    basic_auth_user: "bar",
+    basic_auth: "bar:foo",
   }
   mp.sqs_transport_options = {
     queue: "my_data_stream"
@@ -217,8 +217,7 @@ $magic_pipe = MagicPipe.build do |mp|
     url: "https://my.receiver.service/messages",
     dynamic_path_builder: -> (topic) { topic }
 
-    basic_auth_user: "foo",
-    basic_auth_password: "bar",
+    basic_auth: "foo:bar",
 
     timeout: 2,
     open_timeout: 3,

--- a/lib/magic_pipe/config.rb
+++ b/lib/magic_pipe/config.rb
@@ -74,8 +74,7 @@ module MagicPipe
         #
         dynamic_path_builder: nil,
 
-        basic_auth_user: "missing",
-        basic_auth_password: "x",
+        basic_auth: "missing:x",
         timeout: 2,
         open_timeout: 3,
       }

--- a/spec/magic_pipe/config_spec.rb
+++ b/spec/magic_pipe/config_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe MagicPipe::Config do
             actual = subject.https_transport_options
 
             expect(actual[:url]).to_not be_nil
-            expect(actual[:basic_auth_user]).to_not be_nil
-            expect(actual[:basic_auth_password]).to_not be_nil
+            expect(actual[:basic_auth]).to_not be_nil
             expect(actual[:timeout]).to_not be_nil
             expect(actual[:open_timeout]).to_not be_nil
 
@@ -59,8 +58,7 @@ RSpec.describe MagicPipe::Config do
             expect(actual[:url]).to eq "http://foo.bar"
             expect(actual[:dynamic_path_builder]).to eq fn
 
-            expect(actual[:basic_auth_user]).to_not be_nil
-            expect(actual[:basic_auth_password]).to_not be_nil
+            expect(actual[:basic_auth]).to_not be_nil
             expect(actual[:timeout]).to_not be_nil
             expect(actual[:open_timeout]).to_not be_nil
           end

--- a/spec/magic_pipe/transports/https_spec.rb
+++ b/spec/magic_pipe/transports/https_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe MagicPipe::Transports::Https do
   let(:https_options) do
     {
       url: base_url,
-      basic_auth_user: basic_auth_user,
-      basic_auth_password: "x",
+      basic_auth: "#{basic_auth_user}:x",
     }
   end
 
@@ -105,6 +104,18 @@ RSpec.describe MagicPipe::Transports::Https do
       end
 
       let(:target_url) { base_url.sub("/test", "/marsupials-marsupials/foo") }
+
+      it_submits_a_request_with_the_correct_data
+    end
+
+    describe "when using a dynamic `basic_auth`" do
+      let(:target_url) { base_url }
+      let(:https_options) do
+        super().merge(
+          basic_auth: -> (topic) { "test-#{topic}:foobar" }
+        )
+      end
+      let(:auth_header) { "Basic " + Base64.strict_encode64("test-marsupials:foobar") }
 
       it_submits_a_request_with_the_correct_data
     end


### PR DESCRIPTION
Allow to set the `basic_auth` config as a proc which gets the topic name passed.
Example:
```ruby
basic_auth: ->(topic) {
    username = ENV["TOPIC_#{topic.singularize.upcase}_USER"]
    password = ENV["SECRET_PASSWORD"]
    "#{username}:#{password}"
}
```
It should always return a string in the format `USERNAME:PASSWORD`. Instead
of using a proc this string can be set directly:
```ruby
basic_auth: "foo:bar"
```
In favor of this `basic_auth_user` and `basic_auth_password` have been removed.