### PR TITLE
Report HTTP Transport failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.3
-  - 2.3.6
-  - 2.2.9
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 script:
   - bundle exec rspec
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MagicPipe Changelog
 
+## v0.4.0 (Unreleased)
+
+Bug fix: Ensure that the `Https` transport raises an exception when the HTTP POST request fails.
+
 ## v0.3.0
 
 * Allow to set the `basic_auth` config as a proc which gets the topic name passed. (thanks @Crunch09, https://github.com/tompave/magic_pipe/pull/1)

--- a/lib/magic_pipe/errors.rb
+++ b/lib/magic_pipe/errors.rb
@@ -11,4 +11,16 @@ module MagicPipe
     end
     attr_reader :message
   end
+
+  module Transports
+    class SubmitFailedError < MagicPipe::Error
+      def initialize(transport_klass)
+        @message = "#{transport_klass} couldn't submit message"
+      end
+      attr_reader :message
+    end
+
+    class NotImplementedError < SubmitFailedError
+    end
+  end
 end

--- a/lib/magic_pipe/senders/async.rb
+++ b/lib/magic_pipe/senders/async.rb
@@ -27,7 +27,7 @@ module MagicPipe
           )
 
           payload = codec.new(envelope).encode
-          client.transport.submit(payload, metadata)
+          client.transport.submit!(payload, metadata)
 
           track_success(client.metrics, topic)
         rescue => e

--- a/lib/magic_pipe/senders/sync.rb
+++ b/lib/magic_pipe/senders/sync.rb
@@ -10,7 +10,7 @@ module MagicPipe
         metadata = build_metadata
         envelope = build_message(metadata)
         payload = @codec.new(envelope).encode
-        @transport.submit(payload, metadata)
+        @transport.submit!(payload, metadata)
         track_success(@metrics, @topic)
       rescue => e
         track_failure(@metrics, @topic)

--- a/lib/magic_pipe/transports/base.rb
+++ b/lib/magic_pipe/transports/base.rb
@@ -10,7 +10,7 @@ module MagicPipe
       attr_reader :metrics, :logger
 
       def submit(payload, metadata)
-        raise NotImplementedError
+        raise MagicPipe::Transports::NotImplementedError
       end
     end
   end

--- a/lib/magic_pipe/transports/base.rb
+++ b/lib/magic_pipe/transports/base.rb
@@ -9,7 +9,7 @@ module MagicPipe
 
       attr_reader :metrics, :logger
 
-      def submit(payload, metadata)
+      def submit!(payload, metadata)
         raise MagicPipe::Transports::NotImplementedError
       end
     end

--- a/lib/magic_pipe/transports/debug.rb
+++ b/lib/magic_pipe/transports/debug.rb
@@ -6,7 +6,7 @@ module MagicPipe
       def initialize(*)
       end
 
-      def submit(payload, metadata)
+      def submit!(payload, metadata)
         $magic_pipe_out = {
           payload: payload,
           metadata: metadata

--- a/lib/magic_pipe/transports/https.rb
+++ b/lib/magic_pipe/transports/https.rb
@@ -20,7 +20,7 @@ module MagicPipe
       # TODO: should this raise an error on failure?
       # So that it can be retried?
       #
-      def submit(payload, metadata)
+      def submit!(payload, metadata)
         username, password = basic_auth(metadata[:topic])
         @conn.basic_auth(username, password || "x")
         resp = @conn.post do |r|

--- a/lib/magic_pipe/transports/https.rb
+++ b/lib/magic_pipe/transports/https.rb
@@ -23,7 +23,7 @@ module MagicPipe
       def submit(payload, metadata)
         username, password = basic_auth(metadata[:topic])
         @conn.basic_auth(username, password || "x")
-        @conn.post do |r|
+        resp = @conn.post do |r|
           path = dynamic_path(metadata[:topic])
           r.url(path) if path
 
@@ -31,6 +31,10 @@ module MagicPipe
           r.headers["X-MagicPipe-Sent-At"] = metadata[:time]
           r.headers["X-MagicPipe-Topic"] = metadata[:topic]
           r.headers["X-MagicPipe-Producer"] = metadata[:producer]
+        end
+
+        unless resp.success?
+          raise SubmitFailedError, self.class
         end
       end
 

--- a/lib/magic_pipe/transports/log.rb
+++ b/lib/magic_pipe/transports/log.rb
@@ -7,7 +7,7 @@ module MagicPipe
         super(config, metrics)
       end
 
-      def submit(payload, _metadata)
+      def submit!(payload, _metadata)
         @logger.info "[Trasport#submit]: ↩️\n#{payload}\n"
       end
     end

--- a/lib/magic_pipe/transports/multi.rb
+++ b/lib/magic_pipe/transports/multi.rb
@@ -9,10 +9,10 @@ module MagicPipe
       end
 
 
-      def submit(payload, metadata)
+      def submit!(payload, metadata)
         @transports.map do |transport|
           begin
-            transport.submit(payload, metadata)
+            transport.submit!(payload, metadata)
           rescue => e
             log_error(e, transport)
           end

--- a/lib/magic_pipe/transports/sqs.rb
+++ b/lib/magic_pipe/transports/sqs.rb
@@ -18,7 +18,7 @@ module MagicPipe
       # The AWS SQS client will raise an error if it can't
       # submit the message.
       #
-      def submit(payload, metadata)
+      def submit!(payload, metadata)
         send_message(payload, metadata)
       end
 

--- a/lib/magic_pipe/transports/sqs.rb
+++ b/lib/magic_pipe/transports/sqs.rb
@@ -15,6 +15,9 @@ module MagicPipe
       end
 
 
+      # The AWS SQS client will raise an error if it can't
+      # submit the message.
+      #
       def submit(payload, metadata)
         send_message(payload, metadata)
       end

--- a/spec/magic_pipe/senders/async_spec.rb
+++ b/spec/magic_pipe/senders/async_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe MagicPipe::Senders::Async do
       end
 
       it "submits the correct payload to the transport" do
-        expect(client.transport).to receive(:submit).with(
+        expect(client.transport).to receive(:submit!).with(
           expected_payload,
           {
             topic: topic,
@@ -127,7 +127,7 @@ RSpec.describe MagicPipe::Senders::Async do
       describe "tracking and metrics" do
         context "on success" do
           before do
-            allow(client.transport).to receive(:submit)
+            allow(client.transport).to receive(:submit!)
           end
 
           it "tracks the action with the metrics object" do
@@ -141,7 +141,7 @@ RSpec.describe MagicPipe::Senders::Async do
 
         context "on failure" do
           before do
-            allow(client.transport).to receive(:submit) do
+            allow(client.transport).to receive(:submit!) do
               raise MagicPipe::Error, "oh no"
             end
           end

--- a/spec/magic_pipe/senders/sync_spec.rb
+++ b/spec/magic_pipe/senders/sync_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe MagicPipe::Senders::Sync do
 
     it "encodes the data with the codec and sends it with the transport" do
       expect(codec_k).to receive(:new).with(envelope).and_return(codec)
-      expect(transport_i).to receive(:submit).with(payload, metadata)
+      expect(transport_i).to receive(:submit!).with(payload, metadata)
       perform
     end
 
@@ -78,7 +78,7 @@ RSpec.describe MagicPipe::Senders::Sync do
       context "on success" do
         before do
           allow(codec_k).to receive(:new).with(envelope).and_return(codec)
-          allow(transport_i).to receive(:submit).with(payload, metadata)
+          allow(transport_i).to receive(:submit!).with(payload, metadata)
         end
 
         it "tracks the action with the metrics object" do
@@ -93,7 +93,7 @@ RSpec.describe MagicPipe::Senders::Sync do
       context "on failure" do
         before do
           allow(codec_k).to receive(:new).with(envelope).and_return(codec)
-          allow(transport_i).to receive(:submit).with(payload, metadata) do
+          allow(transport_i).to receive(:submit!).with(payload, metadata) do
             raise MagicPipe::Error, "oh no"
           end
         end

--- a/spec/magic_pipe/transports/https_spec.rb
+++ b/spec/magic_pipe/transports/https_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe MagicPipe::Transports::Https do
 
 
     def perform
-      subject.submit(payload, metadata)
+      subject.submit!(payload, metadata)
     end
 
 

--- a/spec/magic_pipe/transports/https_spec.rb
+++ b/spec/magic_pipe/transports/https_spec.rb
@@ -126,7 +126,10 @@ RSpec.describe MagicPipe::Transports::Https do
       end
 
       it "raises an exception" do
-        expect { perform }.to raise_error(MagicPipe::Transports::SubmitFailedError)
+        expect { perform }.to raise_error(
+          MagicPipe::Transports::SubmitFailedError,
+          "MagicPipe::Transports::Https couldn't submit message"
+        )
       end
     end
   end

--- a/spec/magic_pipe/transports/https_spec.rb
+++ b/spec/magic_pipe/transports/https_spec.rb
@@ -119,5 +119,15 @@ RSpec.describe MagicPipe::Transports::Https do
 
       it_submits_a_request_with_the_correct_data
     end
+
+    describe "when the HTTP request fails" do
+      before do
+        stub_request(:post, base_url).to_return(status: 504)
+      end
+
+      it "raises an exception" do
+        expect { perform }.to raise_error(MagicPipe::Transports::SubmitFailedError)
+      end
+    end
   end
 end

--- a/spec/magic_pipe/transports/log_spec.rb
+++ b/spec/magic_pipe/transports/log_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MagicPipe::Transports::Log do
     end
 
     def perform
-      subject.submit(payload, metadata)
+      subject.submit!(payload, metadata)
     end
 
     it "just logs the payload" do

--- a/spec/magic_pipe/transports/multi_spec.rb
+++ b/spec/magic_pipe/transports/multi_spec.rb
@@ -40,24 +40,24 @@ RSpec.describe MagicPipe::Transports::Multi do
     end
 
     def perform
-      subject.submit(payload, metadata)
+      subject.submit!(payload, metadata)
     end
 
     it "forwards the payload to all the nested transports" do
-      expect(fake_https).to receive(:submit).with(payload, metadata)
-      expect(fake_sqs).to receive(:submit).with(payload, metadata)
+      expect(fake_https).to receive(:submit!).with(payload, metadata)
+      expect(fake_sqs).to receive(:submit!).with(payload, metadata)
       perform
     end
 
     describe "if one of the transports raises an error" do
       before do
-        expect(fake_https).to receive(:submit) do
+        expect(fake_https).to receive(:submit!) do
           raise "oh no"
         end
       end
 
       it "logs the error and doesn't halt the pipeline" do
-        expect(fake_sqs).to receive(:submit).with(payload, metadata)
+        expect(fake_sqs).to receive(:submit!).with(payload, metadata)
 
         expect(config.logger).to receive(:error).with(
           %r{Transports::Multi, error submitting with}

--- a/spec/magic_pipe/transports/sqs_spec.rb
+++ b/spec/magic_pipe/transports/sqs_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MagicPipe::Transports::Sqs do
     end
 
     def perform
-      subject.submit(payload, metadata)
+      subject.submit!(payload, metadata)
     end
 
     it "publishes a message to SQS with the correct data" do


### PR DESCRIPTION
The `Https` transport was allowing HTTP POST requests to fail silently.