### PR TITLE
Better reporting for error messages

### DIFF
--- a/lib/magic_pipe/errors.rb
+++ b/lib/magic_pipe/errors.rb
@@ -10,6 +10,7 @@ module MagicPipe
       @message = "Can't resolve class name '#{class_name}' (#{context})"
     end
     attr_reader :message
+    alias_method :to_s, :message
   end
 
   module Transports
@@ -18,6 +19,7 @@ module MagicPipe
         @message = "#{transport_klass} couldn't submit message (#{message})"
       end
       attr_reader :message
+      alias_method :to_s, :message
     end
 
     class NotImplementedError < SubmitFailedError

--- a/spec/magic_pipe/transports/https_spec.rb
+++ b/spec/magic_pipe/transports/https_spec.rb
@@ -125,11 +125,29 @@ RSpec.describe MagicPipe::Transports::Https do
         stub_request(:post, base_url).to_return(status: 504, body: "on, no!")
       end
 
+      let(:error_msg) do
+        "MagicPipe::Transports::Https couldn't submit message (HTTP response: status=504 body=\"on, no!\")"
+      end
+
       it "raises an exception" do
         expect { perform }.to raise_error(
           MagicPipe::Transports::SubmitFailedError,
-          "MagicPipe::Transports::Https couldn't submit message (HTTP response: status=504 body=\"on, no!\")"
+          error_msg
         )
+      end
+
+      specify "the exception returns the message with #to_s" do
+        # This is important because some error trackers will call #to_s
+        # instead of #message, for example NewRelic.
+        error = nil
+
+        begin
+          perform
+        rescue => e
+          error = e
+        end
+
+        expect(error.to_s).to eq error_msg
       end
     end
   end


### PR DESCRIPTION
NewRelic doesn't correctly report the error messages unless they're returned by `#to_s`.
https://github.com/newrelic/rpm/blob/5.5.0.348/lib/new_relic/noticed_error.rb#L183

Which seems reasonable, since `#message` should just delegate to `#to_s`: http://ruby-doc.org/core-2.5.3/Exception.html#method-i-message

This PR fixes that.