### PR TITLE
[DEFF-547] Extend magic_pipe to allow tracing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    magic_pipe (0.4.2)
+    magic_pipe (0.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -89,4 +89,4 @@ DEPENDENCIES
   webmock (~> 3.3)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/lib/magic_pipe/client.rb
+++ b/lib/magic_pipe/client.rb
@@ -17,6 +17,7 @@ module MagicPipe
     attr_reader :name, :config, :codec, :transport, :sender, :loader, :metrics
 
     def send_data(object:, topic:, wrapper: nil, time: Time.now.utc)
+      config.before_send.call
       sender.new(
         object,
         topic,
@@ -27,6 +28,7 @@ module MagicPipe
         @config,
         @metrics
       ).call
+      config.after_send.call
       true
     end
 

--- a/lib/magic_pipe/config.rb
+++ b/lib/magic_pipe/config.rb
@@ -17,6 +17,8 @@ module MagicPipe
       :https_transport_options,
       :sqs_transport_options,
       :async_transport_options,
+      :before_send,
+      :after_send,
     ]
 
     attr_accessor *FIELDS
@@ -43,6 +45,8 @@ module MagicPipe
       @sender ||= :sync
       @codec ||= :yaml
       @transport ||= :log
+      @before_send ||= Proc.new {}
+      @after_send ||= Proc.new {}
 
       set_https_defaults
       set_sqs_defaults

--- a/lib/magic_pipe/version.rb
+++ b/lib/magic_pipe/version.rb
@@ -1,3 +1,3 @@
 module MagicPipe
-  VERSION = "0.4.2"
+  VERSION = "0.5.0"
 end

--- a/spec/magic_pipe/client_spec.rb
+++ b/spec/magic_pipe/client_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe MagicPipe::Client do
+  let(:logger) { double(:logger, start: nil, finish: nil) }
   let(:config) do
     MagicPipe::Config.new do |c|
       c.client_name = :foo_bar
@@ -6,6 +7,8 @@ RSpec.describe MagicPipe::Client do
       c.transport = :https
       c.https_transport_options = {} # let the defaults apply
       c.sender = :sync
+      c.before_send = -> { logger.start }
+      c.after_send = -> { logger.finish }
     end
   end
 
@@ -61,7 +64,9 @@ RSpec.describe MagicPipe::Client do
         subject.metrics
       ).and_return(sender)
 
-      expect(sender).to receive(:call)
+      expect(logger).to receive(:start).ordered
+      expect(sender).to receive(:call).ordered
+      expect(logger).to receive(:finish).ordered
 
       perform
     end


### PR DESCRIPTION
# [Context](https://deliveroo.atlassian.net/browse/DEFF-547)

I originally thought about implementing an [`around_filter`](https://apidock.com/rails/ActionController/Filters/ClassMethods/around_filter) but skimming through DD's [docs](https://docs.datadoghq.com/tracing/setup/ruby/#asynchronous-tracing) I found a cleaner way of doing so.  A consumer of this app would do something like:

```ruby
    MagicPipe::Config.new do |c|
      c.client_name = :foo_bar
      c.codec = :json
      c.transport = :https
      c.https_transport_options = {} # let the defaults apply
      c.sender = :sync
      c.before_send = -> { Datadog.tracer.trace("magic_pipe.send") }
      c.after_send = -> { Datadog.tracer. active_span&.finish }
    end
```